### PR TITLE
New option "opcodes" (disabled/enabled) to display opcodes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,19 @@
 						"Both bytecode size and LOC count are shown"
 					],
 					"default": "bytecode"
+				},
+				"z80-asm-meter.opcodes": {
+					"type": "string",
+					"description": "Controls the visibility of the opcodes information in the status bar",
+					"enum": [
+						"disabled",
+						"enabled"
+					],
+					"enumDescriptions": [
+						"Opcodes information is not shown",
+						"Opcodes information is shown as an indication"
+					],
+					"default": "disabled"
 				}
 			}
 		}

--- a/src/z80Block.ts
+++ b/src/z80Block.ts
@@ -14,9 +14,13 @@ export class Z80Block {
     public size: number = 0;
     public loc: number = 0;
 
+    // Opcodes information
+    public opcodes: string = "";
+
     // Display configuration
     private timingConfiguration: string | undefined = undefined;
     private sizeConfiguration: string | undefined = undefined;
+    private opcodesConfiguration: string | undefined = undefined;
 
     constructor(sourceCode: string | undefined) {
 
@@ -56,6 +60,7 @@ export class Z80Block {
         // Saves display configuration
         this.timingConfiguration = configuration.get("timing", "disabled");
         this.sizeConfiguration = configuration.get("size", "disabled");
+        this.opcodesConfiguration = configuration.get("opcodes", "disabled");
     }
 
     public addInstruction(instruction: Z80Instruction | undefined) {
@@ -78,6 +83,8 @@ export class Z80Block {
 
         this.size += instruction.getSize();
         this.loc++;
+
+        this.opcodes += instruction.getOpcode() + `\n`;
     }
 
     public getTimingInformation(): Record<string, string | undefined> | undefined {
@@ -122,6 +129,23 @@ export class Z80Block {
                 : undefined,
             "tooltip":
                 sizeText + " in " + this.loc + " selected " + (this.loc === 1 ? "line" : "lines") + " of code (LoC)",
+        };
+    }
+
+    public getOpcodesInformation(): Record<string, string | undefined> | undefined {
+
+        // (empty or disabled)
+        if ((this.loc === 0) || (this.opcodesConfiguration === "disabled")) {
+            return undefined;
+        }
+
+        const opcodesText = this.opcodes;
+        return {
+            "text":
+                this.opcodesConfiguration === "enabled" ? opcodesText
+                : undefined,
+            "tooltip":
+                opcodesText,
         };
     }
 

--- a/src/z80instruction.ts
+++ b/src/z80instruction.ts
@@ -18,6 +18,7 @@ export class Z80Instruction {
         this.z80M1Timing = parseTimings(z80M1Timing);
         this.cpcTiming = parseTimings(cpcTiming);
         this.size = parseInt(size);
+        this.opcode = opcode;
     }
 
     /**
@@ -53,6 +54,13 @@ export class Z80Instruction {
      */
     public getSize(): number {
         return this.size;
+    }
+
+    /**
+     * @returns The opcode
+     */
+    public getOpcode(): string {
+        return this.opcode;
     }
 
     /**

--- a/src/z80instructionSet.ts
+++ b/src/z80instructionSet.ts
@@ -18,9 +18,9 @@ export class Z80InstructionSet {
             const rawZ80Timing = rawData[1];
             const rawZ80M1Timing = rawData[2];
             const rawCPCTiming = rawData[3];
-
+            const rawOpcode = rawData[4];
             const rawSize = rawData[5];
-            const instruction = new Z80Instruction(rawInstruction, rawZ80Timing, rawZ80M1Timing, rawCPCTiming, rawSize);
+            const instruction = new Z80Instruction(rawInstruction, rawZ80Timing, rawZ80M1Timing, rawCPCTiming, rawSize, rawOpcode);
 
             const mnemonic = instruction.getMnemonic();
 

--- a/src/z80meterController.ts
+++ b/src/z80meterController.ts
@@ -5,6 +5,7 @@ export class Z80MeterController {
 
     private _timingStatusBarItem: StatusBarItem | undefined;
     private _sizeStatusBarItem: StatusBarItem | undefined;
+    private _opcodesStatusBarItem: StatusBarItem | undefined;
     private _disposable: Disposable;
 
 	constructor() {
@@ -74,6 +75,19 @@ export class Z80MeterController {
             this._timingStatusBarItem.tooltip = timing["tooltip"];
             this._timingStatusBarItem.show();
         }
+
+        const opcodes = z80Block.getOpcodesInformation();
+        if (!opcodes) {
+            this.hideOpcodesStatusBarItem();
+
+        } else {
+            if (!this._opcodesStatusBarItem) {
+                this._opcodesStatusBarItem = window.createStatusBarItem();
+            }
+            this._opcodesStatusBarItem.text = "$(file-binary) " + opcodes["text"];
+            this._opcodesStatusBarItem.tooltip = opcodes["tooltip"];
+            this._opcodesStatusBarItem.show();
+        }
     }
 
     private hideSizeStatusBarItem() {
@@ -88,6 +102,12 @@ export class Z80MeterController {
         }
     }
 
+    private hideOpcodesStatusBarItem() {
+        if (this._opcodesStatusBarItem) {
+            this._opcodesStatusBarItem.hide();
+        }
+    }
+
 	dispose() {
 		this._disposable.dispose();
         if (this._timingStatusBarItem) {
@@ -97,6 +117,10 @@ export class Z80MeterController {
         if (this._sizeStatusBarItem) {
             this._sizeStatusBarItem.dispose();
             this._sizeStatusBarItem = undefined;
+        }
+        if (this._opcodesStatusBarItem) {
+            this._opcodesStatusBarItem.dispose();
+            this._opcodesStatusBarItem = undefined;
         }
 	}
 }


### PR DESCRIPTION
When enabled, the status line displays the opcode of the first instruction as an indication and tooltip displays the list of opcodes per line for all the selected instructions.

