### PR TITLE
Fix label handling

### DIFF
--- a/src/z80utils.ts
+++ b/src/z80utils.ts
@@ -11,7 +11,7 @@ export function formatTiming(t: number[]): string {
 
 export function extractInstructionsFrom(rawLine: string): string[] | undefined {
     // Removes surrounding label, whitespace and/or comments
-    const line = rawLine.replace(/(^\s*\S+:)|((;|\/\/).*$)/, "").trim();
+    const line = rawLine.replace(/(^\S+[\s:])|((;|\/\/).*$)/, "").trim();
     if (line.length === 0) {
         return undefined;
     }


### PR DESCRIPTION
At least some Z80 assemblers (such as pasmo and sjasmplus) define a label as (roughly) a sequence of non-spaces from the beginning of a line, terminated with a space or colon (so, colon is optional). The regexp currently used for getting rid of labels does not take such syntax into account:
```assembly
some_label    ld a, (hl)  ; won't be accounted
```
Also, in a string of mnemonics separated by a colon, the first mnemonic will be incorrectly identified as a label and discarded if it consists of a single word:
```assembly
              ldir: inc de: ret  ; here, ldir will be identified as a label and thrown out
```
This PR fixes that, but can probably lead to problems with other assemblers that I'm not aware of.