### PR TITLE
Removed deprecated language id for "asm-collection" in favor of new "asm-z80-sjasmplus" language id.

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 							"null"
 						],
 						"default": [
-							"asm-collection",
+							"asm-z80-sjasmplus",
 							"pasmo",
 							"z80",
 							"z80-asm",


### PR DESCRIPTION
Hi,
I'm the author of asm-code-lens which introduced the "asm-collection" language id a few years back.
This language id is deprecated now and no longer used by asm-code-lens.
With this PR I propose to change it also in z80-asm-meter as I got already error reports, stating that z80-asm-meter is not working anymore together with new asm-code-lens.

(Would help me a bit if you could integrate it ... :-)